### PR TITLE
Fix getting length of $data in xmlrpcmsg::parseResponse

### DIFF
--- a/src/xmlrpc-3.0/lib/xmlrpc.inc
+++ b/src/xmlrpc-3.0/lib/xmlrpc.inc
@@ -2292,7 +2292,7 @@ class xmlrpcmsg
         xml_set_default_handler($parser, 'xmlrpc_dh');
 
         // first error check: xml not well formed
-        if (!xml_parse($parser, $data, count($data))) {
+        if (!xml_parse($parser, $data, strlen($data))) {
             // thanks to Peter Kocks <peter.kocks@baygate.com>
             if ((xml_get_current_line_number($parser)) == 1) {
                 $errstr = 'XML error at line 1, check URL';


### PR DESCRIPTION
`$data` is a string, and checking if it's empty with `count()` throws warnings/errors (see for example https://3v4l.org/Br8Ii )